### PR TITLE
create-kubeconfig: change the argument to specify the serviceaccount

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository contains some useful scripts for operating Kubernetes.
 
-- `create-kubeconfig`: Create a kubeconfig with the specified serviceaccount token and output it to stdout.
+- `create-kubeconfig`: Create a kubeconfig to access the apiserver with the specified serviceaccount and outputs it to stdout.
 - `wait-until-pods-ready`: Wait for all pods to be ready in the current namespace.
 
 ## License

--- a/create-kubeconfig
+++ b/create-kubeconfig
@@ -9,9 +9,9 @@
 set -e
 
 if [[ $# == 0 ]]; then
-  echo "Usage: $0 SERVICEACCOUNT_TOKEN [kubectl options]" >&2
+  echo "Usage: $0 SERVICEACCOUNT [kubectl options]" >&2
   echo "" >&2
-  echo "This script creates a kubeconfig with the specified serviceaccount token and outputs it to stdout." >&2
+  echo "This script creates a kubeconfig to access the apiserver with the specified serviceaccount and outputs it to stdout." >&2
 
   exit 1
 fi
@@ -20,12 +20,16 @@ function _kubectl() {
   kubectl $@ $kubectl_options
 }
 
-secret="$1"
+serviceaccount="$1"
 kubectl_options="${@:2}"
 
-serviceaccount="$(_kubectl get secret "$secret" -o "jsonpath={.metadata.annotations.kubernetes\.io\/service-account\.name}")"
-if [[ -z "$serviceaccount" ]]; then
-  echo "$secret is NOT serviceaccount token" >&2
+if ! secret="$(_kubectl get serviceaccount "$serviceaccount" -o 'jsonpath={.secrets[0].name}' 2>/dev/null)"; then
+  echo "serviceaccounts \"$serviceaccount\" not found." >&2
+  exit 2
+fi
+
+if [[ -z "$secret" ]]; then
+  echo "serviceaccounts \"$serviceaccount\" doesn't have a serviceaccount token." >&2
   exit 2
 fi
 


### PR DESCRIPTION
This commit changes the argument from serviceaccount token to the serviceaccount name. With this change, we don't need to know the serviceaccount token in advance. This is breaking change.

```
$ ./create-kubeconfig
Usage: ./create-kubeconfig SERVICEACCOUNT [kubectl options]

This script creates a kubeconfig to access the apiserver with the specified serviceaccount and outputs it to stdout.
```