### PR TITLE
Add force-update-deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ This repository contains some useful scripts for operating Kubernetes.
 
 - `create-kubeconfig`: Create a kubeconfig to access the apiserver with the specified serviceaccount and outputs it to stdout.
 - `wait-until-pods-ready`: Wait for all pods to be ready in the current namespace.
+- `force-update-deployment`: Recreate the pods managed by the specified deployment.
 
 ## License
 

--- a/force-update-deployment
+++ b/force-update-deployment
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+# Copyright 2017, Z Lab Corporation. All rights reserved.
+# Copyright 2017, Kubernetes scripts contributors
+#
+# For the full copyright and license information, please view the LICENSE
+# file that was distributed with this source code.
+
+set -e
+
+if [[ $# == 0 ]]; then
+  echo "Usage: $0 DEPLOYMENT [kubectl options]" >&2
+  echo "" >&2
+  echo "This script recreates the pods managed by the specified deployment." >&2
+  exit 1
+fi
+
+function _kubectl() {
+  kubectl $@ $kubectl_options
+}
+
+deployment="$1"
+updated_at=$(date +%s)
+kubectl_options="${@:2}"
+
+_kubectl patch deployment "$deployment" \
+  -p "{\"spec\":{\"template\":{\"metadata\":{\"annotations\":{\"force-update.zlab.co.jp/updated-at\":\"$updated_at\"}}}}}"


### PR DESCRIPTION
This script recreates the pods managed by the specified deployment. This is useful for reloading configmaps and for re-pulling latest container images.