### PR TITLE
Add a new script file, "apiversion2resources"

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,16 @@ This repository contains some useful scripts for operating Kubernetes.
 - `create-kubeconfig`: Create a kubeconfig to access the apiserver with the specified serviceaccount and outputs it to stdout.
 - `wait-until-pods-ready`: Wait for all pods to be ready in the current namespace.
 - `force-update-deployment`: Recreate the pods managed by the specified deployment.
+- `apiversion2resources`: Convert API versions read from STDIN to resources in the form of `apiversion.resource`.
+
+## How to use
+
+**apiversion2resources**
+
+```
+# Convert the supported API versions on the server
+$ kubectl api-versions | apiversion2resources
+```
 
 ## License
 

--- a/apiversion2resources
+++ b/apiversion2resources
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+# Copyright 2018, Z Lab Corporation. All rights reserved.
+# Copyright 2018, Kubernetes scripts contributors
+#
+# For the full copyright and license information, please view the LICENSE
+# file that was distributed with this source code.
+
+set -e
+set -o pipefail
+
+apiversion2resources() {
+  local apiversion="$1"
+  local url=""
+
+  if [[ "$apiversion" == "v1" ]]; then
+    url="/api/v1"
+  else
+    url="/apis/$apiversion"
+  fi
+
+  kubectl get --raw "$url" | jq -r ".resources[] | if (.name | contains(\"/\")) then empty else .kind end" | grep -v "/" | sort | sed -e "s#^#$apiversion.#"
+}
+
+export -f apiversion2resources
+
+cat | xargs -I% -P3 -n1 bash -c "apiversion2resources %" | sort
+# vim: ai ts=2 sw=2 et sts=2 ft=sh


### PR DESCRIPTION
This PR adds a new script file, "apiversion2resources" which converts API versions read from STDIN to resources in the form of `apiversion.resource`.

```
# Convert the supported API versions on the server
$ kubectl api-versions | apiversion2resources
```